### PR TITLE
pass svelte options to compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,12 @@ module.exports = function transformSvelte(file, options) {
 			const name = sanitizeJavaScriptFunctionName(base.replace(extension, ''))
 
 			try {
-				const { code, map } = compile(data, {
+				const svelteOptions = Object.assign({}, options.svelte, {
 					name,
 					filename: base,
 					format: 'cjs'
 				})
+				const { code, map } = compile(data, svelteOptions)
 				this.push(code)
 				this.push('\n//# sourceMappingURL=' + map.toUrl())
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Browserify transform for Svelte",
   "main": "index.js",
   "scripts": {
-    "test": "rm -f test/build.js && browserify -t [ ./index.js --extensions [.htmlz .svelte .html] ] -d test/test.js -o test/build.js"
+    "test": "rm -f test/build.js && browserify -t [ ./index.js --extensions [.htmlz .svelte .html] --svelte [ --dev=true ] ] -d test/test.js -o test/build.js"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,49 @@ Defaults to transforming all `.html` and `.svelte` files.  You can overwrite the
 browserify -t [ sveltify --extensions [.htmlz .svelte] ] myfile.js
 ```
 
+```json
+{
+  "browserify": {
+    "transform": [
+      [
+        "sveltify",
+        {
+          "extensions": [
+            ".html",
+            ".svelte"
+          ]
+        }
+      ]
+    ]
+  }
+}
+```
+
+## Svelte Options
+
+Pass options to the Svelte compiler with the `svelte` property:
+
+```sh
+browserify -t [ sveltify --svelte [ --dev=true ] ] myfile.js
+```
+
+```json
+{
+  "browserify": {
+    "transform": [
+      [
+        "sveltify",
+        {
+          "svelte": {
+            "dev": true
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
 ## License
 
 [WTFPL](http://wtfpl2.com/)


### PR DESCRIPTION
Motivation: wanting to pass any of the [Svelte options](https://github.com/sveltejs/svelte#options) to the compiler, particularly the `dev` option.