### PR TITLE
Update Svelte to v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 test/build.js
+test/build.js.tmp-browserify-*

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const { basename, extname } = require(`path`)
-const { compile } = require(`svelte`)
+const { compile } = require(`svelte/compiler`)
 const through = require(`through2`)
 const toPascalCase = require(`just-pascal-case`)
 
@@ -21,7 +21,7 @@ module.exports = function transformSvelte(file, options) {
 			const name = toPascalCase(base.replace(extension, ``))
 
 			try {
-				const svelteOptions = Object.assign({}, options.svelte, {
+				const {_, ...svelteOptions} = Object.assign({}, options.svelte, {
 					name,
 					filename: base,
 					format: `cjs`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -929,6 +929,14 @@
         "signal-exit": "^3.0.0"
       }
     },
+    "magic-string": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -1456,6 +1464,11 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg=="
     },
     "spdx-correct": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1563,9 +1563,9 @@
       }
     },
     "svelte": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.1.tgz",
-      "integrity": "sha512-TpXdfukSkmWkMnH6PPVm7FRW8SSFcTyqBiP+6VN8rtZJ7Lp1Xbf/e3oz73eQBxF0UPZw1aAn1b91lX2XTeD3zg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.0.0.tgz",
+      "integrity": "sha512-4QQ7eBuVw/t0kMSSjLCiAjQYTj7ZF0OtH24YOWtTrTJHTLd58gEAPZeKSGOYDXtwpcrMi4Cxo3MgEbdI1m4erg=="
     },
     "syntax-error": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "just-pascal-case": "^1.1.0",
-    "svelte": "^2",
+    "svelte": "^3.0.0",
     "through2": "^2.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "just-pascal-case": "^1.1.0",
+    "magic-string": "0.25.2",
     "svelte": "^3.0.0",
     "through2": "^2.0.5"
   }

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 # sveltify
 
-A Browserify transform allowing you to require [Svelte](https://svelte.technology) templates.
+A Browserify transform allowing you to require [Svelte](https://svelte.dev) templates.
 
 Defaults to transforming all `.html` and `.svelte` files.  You can overwrite the transformed extensions with the `extensions` argument.
 
-**If you're using `svelte@2`, you need `sveltify@2`, and vice versa.**
+**If you're using `svelte@3`, you need `sveltify@3`, and vice versa.**
 
 ## Usage
 

--- a/test/Demo.html
+++ b/test/Demo.html
@@ -4,7 +4,5 @@
 </p>
 
 <script>
-export default {
-	data: () => ({ name: 'world' })
-}
+export let name = 'world'
 </script>

--- a/test/ReferenceSelf.html
+++ b/test/ReferenceSelf.html
@@ -8,3 +8,7 @@
 	</li>
 {/each}
 </ul>
+
+<script>
+export let items = []
+</script>

--- a/test/ThrowingComponent.html
+++ b/test/ThrowingComponent.html
@@ -2,14 +2,10 @@
 <p>{howdy('bub')}</p>
 
 <script>
+const {onMount} = require('svelte')
 const howdy = require('./test-dependency')
 
-export default {
-	helpers: {
-		howdy
-	},
-	oncreate() {
-		throw new Error('Before you wreck yourself')
-	}
-}
+onMount(() => {
+	throw new Error('Before you wreck yourself')
+})
 </script>

--- a/test/test.js
+++ b/test/test.js
@@ -1,15 +1,13 @@
-const Demo = require('./Demo.html')
-const ThrowingComponent = require('./ThrowingComponent.html')
-const FileWithDashes = require('./file-with-dashes.html')
-const ReferenceSelf = require('./ReferenceSelf.html')
+const Demo = require('./Demo.html').default
+const ThrowingComponent = require('./ThrowingComponent.html').default
+const FileWithDashes = require('./file-with-dashes.html').default
+const ReferenceSelf = require('./ReferenceSelf.html').default
 
 const demo = new Demo({
 	target: document.querySelector('#demo')
 })
 
-demo.set({
-	name: 'Bob'
-})
+demo.$set({name: 'Bob'})
 
 new FileWithDashes({
 	target: document.querySelector('#fileWithDashesComponent')
@@ -17,7 +15,7 @@ new FileWithDashes({
 
 new ReferenceSelf({
 	target: document.querySelector('#referenceSelf'),
-	data: {
+	props: {
 		items: [{
 			label: 'parent',
 			children: [{

--- a/test/test.js
+++ b/test/test.js
@@ -1,30 +1,30 @@
-const Demo = require('./Demo.html').default
-const ThrowingComponent = require('./ThrowingComponent.html').default
-const FileWithDashes = require('./file-with-dashes.html').default
-const ReferenceSelf = require('./ReferenceSelf.html').default
+const Demo = require(`./Demo.html`)
+const ThrowingComponent = require(`./ThrowingComponent.html`)
+const FileWithDashes = require(`./file-with-dashes.html`)
+const ReferenceSelf = require(`./ReferenceSelf.html`)
 
 const demo = new Demo({
-	target: document.querySelector('#demo')
+	target: document.querySelector(`#demo`),
 })
 
-demo.$set({name: 'Bob'})
+demo.$set({ name: `Bob` })
 
 new FileWithDashes({
-	target: document.querySelector('#fileWithDashesComponent')
+	target: document.querySelector(`#fileWithDashesComponent`),
 })
 
 new ReferenceSelf({
-	target: document.querySelector('#referenceSelf'),
+	target: document.querySelector(`#referenceSelf`),
 	props: {
 		items: [{
-			label: 'parent',
+			label: `parent`,
 			children: [{
-				label: 'child'
-			}]
-		}]
-	}
+				label: `child`,
+			}],
+		}],
+	},
 })
 
 new ThrowingComponent({
-	target: document.querySelector('#throwingComponent')
+	target: document.querySelector(`#throwingComponent`),
 })


### PR DESCRIPTION
I'm not 100% happy with this. Svelte v3 brings some new issues:

* Default `import`s of CommonJS modules no longer work (e.g. `import _ from 'lodash';`). `require` can be used instead.
* CommonJS `require`s of Svelte components now need `.default`, e.g. `const MyComponent = require('./MyComponent.svelte').default;`

I'm not sure how these issues can be overcome. Are they Svelte bugs that we wait to get fixed? Do we need to `preprocess` the source to convert our `import`s into `require`s?